### PR TITLE
Configure commitlint to use verbose output

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no -- commitlint --edit ${1}
+npx --no -- commitlint --verbose --edit ${1}


### PR DESCRIPTION
This change makes commitlint output a message even when there are no errors, which makes it easier to confirm that it has run.