### PR TITLE
build(def-infra): exclude `node_modules` in IDEA configuration

### DIFF
--- a/.idea/pwbriggs.github.io.iml
+++ b/.idea/pwbriggs.github.io.iml
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/node_modules" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>


### PR DESCRIPTION
Hide the `node_modules` directory from view in IntelliJ.