### PR TITLE
ci(dependabot): group commitlint dependencies in dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      commitlint:
+        patterns:
+          - "@commitlint/*"


### PR DESCRIPTION
Configure Dependabot to put all updates to packages under the `@commitlint/` scope in one PR.