### PR TITLE
docs: link to site in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pwbriggs.github.io
+# [pwbriggs.github.io](https://pwbriggs.github.io/)
 
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/pwbriggs/pwbriggs.github.io/ci.yaml?logo=github)
 


### PR DESCRIPTION
Make the header ("pwbriggs.github.io") link to the site.