### PR TITLE
ci: don't try to deploy unless on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -32,6 +30,7 @@ jobs:
           path: ./build
 
   deploy:
+    if: github.event_name == "push" && github.ref == "refs/heads/main" # Don't try to deploy (it will fail) if not on main.
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
Update GitHub Actions workflow so it stops trying (and failing) to deploy on PRs and non-main pushes.

Also don't limit where the actions run to just the main branch.