### PR TITLE
ci: actually fix workflow file syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           path: ./build
 
   deploy:
-    if: ${{ github.event_name == "push" && github.ref == "refs/heads/main" }} # Don't try to deploy (it will fail) if not on main.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Don't try to deploy (it will fail) if not on main.
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
Use single quotes around strings, as required by GitHub Actions.